### PR TITLE
Add simple web interface for Task Manager API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ env/
 
 # Logs
 *.log
+
+# Node
+node_modules/
+frontend/node_modules/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -16,14 +16,23 @@ A comprehensive Flask REST API for managing tasks with priorities, due dates, an
 ## Quick Start
 
 ```bash
-# Install Flask
+# Install dependencies
 pip install -r requirements.txt
 
 # Run the app
 python app.py
 ```
 
-API will be available at: http://localhost:5000
+Open http://localhost:5000 in your browser to use the web interface. The API is also available at this address.
+
+## Web Interface
+
+The Flask app serves a simple frontend from the `frontend` directory. It provides:
+
+- A home page with navigation links.
+- A tasks page with side-by-side priority tables, a modal form for new tasks, description toggling on click, and a separate completed list.
+- Each task shows check and trash icons for completion and deletion.
+- Statistics are pinned to the bottom-left corner, and error messages appear inline for failed requests.
 
 ## API Endpoints
 

--- a/app.py
+++ b/app.py
@@ -1,12 +1,17 @@
 from flask import Flask, request, jsonify
 from datetime import datetime
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='frontend', static_url_path='')
 
 # Simple in-memory storage for tasks
 tasks = []
 
 @app.route('/', methods=['GET'])
+def index():
+    return app.send_static_file('index.html')
+
+
+@app.route('/api', methods=['GET'])
 def home():
     return "Task Manager API - Use /tasks endpoint"
 
@@ -165,7 +170,7 @@ def get_stats():
     })
 
 if __name__ == '__main__':
-    print("Starting Enhanced Task Manager API...")
+    print("Starting Task Manager API with web UI...")
     print("Available endpoints:")
     print("   GET  /tasks               - Get all tasks (with filtering)")
     print("   POST /tasks              - Create new task")
@@ -173,5 +178,5 @@ if __name__ == '__main__':
     print("   DELETE /tasks/<id>       - Delete specific task")
     print("   POST /tasks/<id>/complete - Mark task as completed")
     print("   GET  /tasks/stats        - Get task statistics")
-    print("Server running on http://localhost:5000")
+    print("Web interface available at http://localhost:5000/")
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Task Manager</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <nav>
+        <a href="/">Home</a>
+        <a href="/tasks.html">Tasks</a>
+    </nav>
+    <main>
+        <h1>Welcome to Task Manager</h1>
+        <p>This simple web interface connects to the Task Manager API.</p>
+        <p>Use the navigation above to manage your tasks.</p>
+    </main>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,147 @@
+body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: #121212;
+    color: #e0e0e0;
+}
+nav {
+    background: #1e1e1e;
+    padding: 1rem;
+    text-align: center;
+}
+nav a {
+    color: #e0e0e0;
+    margin: 0 1rem;
+    text-decoration: none;
+}
+nav a:hover {
+    text-decoration: underline;
+}
+main {
+    max-width: 1200px;
+    margin: 2rem auto;
+    padding: 0 2rem;
+}
+#task-tables {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+.task-section {
+    flex: 1;
+    margin-top: 1rem;
+    background: #1e1e1e;
+    padding: 1rem;
+    border-radius: 8px;
+}
+.task-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1rem;
+}
+.add-btn {
+    padding: 0.5rem 1rem;
+}
+form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+/* Modal form layout */
+.modal-content form {
+    flex-direction: column;
+}
+input, select, button {
+    padding: 0.5rem;
+    border: none;
+    border-radius: 4px;
+    background: #2c2c2c;
+    color: #e0e0e0;
+}
+button {
+    cursor: pointer;
+    background: #3f51b5;
+    color: #fff;
+}
+.actions {
+    float: right;
+}
+.actions i {
+    margin-left: 0.5rem;
+    cursor: pointer;
+}
+.actions .fa-check {
+    color: #43a047;
+}
+.actions .fa-trash {
+    color: #e53935;
+}
+.task-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.task-table th, .task-table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid #333;
+    text-align: left;
+}
+.completed td:first-child {
+    text-decoration: line-through;
+    color: #777;
+}
+.task-row td:first-child {
+    cursor: pointer;
+}
+.desc-row td {
+    background: #2c2c2c;
+}
+.hidden {
+    display: none;
+}
+/* Modal styling */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+/* Ensure hidden modals stay hidden */
+.modal.hidden {
+    display: none;
+}
+.modal-content {
+    background: #1e1e1e;
+    padding: 1.5rem;
+    border-radius: 8px;
+    min-width: 300px;
+}
+.close {
+    background: none;
+    border: none;
+    color: #e0e0e0;
+    font-size: 1.2rem;
+    align-self: flex-end;
+    cursor: pointer;
+}
+.error {
+    color: #ff6b6b;
+    margin-bottom: 1rem;
+    display: none;
+}
+
+.stats {
+    position: fixed;
+    bottom: 1rem;
+    left: 1rem;
+    background: #1e1e1e;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+}

--- a/frontend/tasks.html
+++ b/frontend/tasks.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Task List</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-1hKFt2C0ZFwEJgqS0bkkCm1cW0XkyR3O6jwxKF1u9IiMaTZGi99Z0eKCbFf8gDuwZQ+Q0jrOqRCk0lr7XmP4PQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+    <nav>
+        <a href="/">Home</a>
+        <a href="/tasks.html">Tasks</a>
+    </nav>
+    <main>
+        <div class="task-header">
+            <h1>Tasks</h1>
+            <button id="open-modal" class="add-btn">New Task</button>
+        </div>
+        <div id="error" class="error"></div>
+        <div id="task-modal" class="modal hidden">
+            <div class="modal-content">
+                <button id="close-modal" class="close">&times;</button>
+                <form id="task-form">
+                    <input type="text" id="title" placeholder="Title" required />
+                    <input type="text" id="description" placeholder="Description" />
+                    <select id="priority">
+                        <option value="low">Low</option>
+                        <option value="medium" selected>Medium</option>
+                        <option value="high">High</option>
+                    </select>
+                    <button type="submit">Save</button>
+                </form>
+            </div>
+        </div>
+        <div id="task-tables">
+            <section class="task-section">
+                <h2>High Priority</h2>
+                <table class="task-table">
+                    <thead>
+                        <tr><th>Title</th></tr>
+                    </thead>
+                    <tbody id="high-body"></tbody>
+                </table>
+            </section>
+            <section class="task-section">
+                <h2>Medium Priority</h2>
+                <table class="task-table">
+                    <thead>
+                        <tr><th>Title</th></tr>
+                    </thead>
+                    <tbody id="medium-body"></tbody>
+                </table>
+            </section>
+            <section class="task-section">
+                <h2>Low Priority</h2>
+                <table class="task-table">
+                    <thead>
+                        <tr><th>Title</th></tr>
+                    </thead>
+                    <tbody id="low-body"></tbody>
+                </table>
+            </section>
+            <section class="task-section">
+                <h2>Completed Tasks</h2>
+                <table class="task-table">
+                    <thead>
+                        <tr><th>Title</th></tr>
+                    </thead>
+                    <tbody id="completed-body"></tbody>
+                </table>
+            </section>
+        </div>
+    </main>
+    <div id="stats" class="stats"></div>
+    <script src="tasks.js"></script>
+</body>
+</html>

--- a/frontend/tasks.js
+++ b/frontend/tasks.js
@@ -1,0 +1,117 @@
+function showError(message) {
+    const errorDiv = document.getElementById('error');
+    if (message) {
+        errorDiv.textContent = message;
+        errorDiv.style.display = 'block';
+    } else {
+        errorDiv.textContent = '';
+        errorDiv.style.display = 'none';
+    }
+}
+
+async function fetchJSON(url, options) {
+    try {
+        const response = await fetch(url, options);
+        if (!response.ok) {
+            let msg = response.statusText;
+            try {
+                const data = await response.json();
+                msg = data.error || msg;
+            } catch (e) {}
+            throw new Error(msg);
+        }
+        return await response.json();
+    } catch (err) {
+        showError(err.message);
+        throw err;
+    }
+}
+
+async function loadTasks() {
+    showError('');
+    try {
+        const data = await fetchJSON('/tasks');
+        const groups = {
+            high: document.getElementById('high-body'),
+            medium: document.getElementById('medium-body'),
+            low: document.getElementById('low-body'),
+            completed: document.getElementById('completed-body')
+        };
+        Object.values(groups).forEach(t => t.innerHTML = '');
+        data.tasks.forEach(task => {
+            let icons = `<i class="fa-solid fa-trash" data-action="delete"></i>`;
+            if (!task.completed) {
+                icons = `<i class="fa-solid fa-check" data-action="complete"></i>` + icons;
+            }
+            const row = document.createElement('tr');
+            row.dataset.id = task.id;
+            row.className = 'task-row' + (task.completed ? ' completed' : '');
+            row.innerHTML = `<td>${task.title}<span class="actions">${icons}</span></td>`;
+            const descRow = document.createElement('tr');
+            descRow.className = 'desc-row hidden';
+            descRow.innerHTML = `<td>${task.description || ''}</td>`;
+            const group = task.completed ? groups.completed : (groups[task.priority] || groups.medium);
+            group.appendChild(row);
+            group.appendChild(descRow);
+        });
+        const stats = await fetchJSON('/tasks/stats');
+        document.getElementById('stats').textContent = `Total: ${stats.total_tasks}, Completed: ${stats.completed_tasks}, Pending: ${stats.pending_tasks}, Overdue: ${stats.overdue_tasks}`;
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+document.getElementById('open-modal').addEventListener('click', () => {
+    document.getElementById('task-modal').classList.remove('hidden');
+});
+
+document.getElementById('close-modal').addEventListener('click', () => {
+    document.getElementById('task-modal').classList.add('hidden');
+});
+
+document.getElementById('task-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const title = document.getElementById('title').value;
+    const description = document.getElementById('description').value;
+    const priority = document.getElementById('priority').value;
+    try {
+        await fetchJSON('/tasks', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ title, description, priority })
+        });
+        e.target.reset();
+        document.getElementById('task-modal').classList.add('hidden');
+        loadTasks();
+    } catch (err) {
+        console.error(err);
+    }
+});
+
+document.getElementById('task-tables').addEventListener('click', async (e) => {
+    const icon = e.target.closest('i[data-action]');
+    if (icon) {
+        const action = icon.dataset.action;
+        const id = icon.closest('tr').dataset.id;
+        try {
+            if (action === 'delete') {
+                await fetchJSON(`/tasks/${id}`, { method: 'DELETE' });
+            } else if (action === 'complete') {
+                await fetchJSON(`/tasks/${id}/complete`, { method: 'POST' });
+            }
+            loadTasks();
+        } catch (err) {
+            console.error(err);
+        }
+        return;
+    }
+    const taskRow = e.target.closest('tr.task-row');
+    if (taskRow) {
+        const descRow = taskRow.nextElementSibling;
+        if (descRow && descRow.classList.contains('desc-row')) {
+            descRow.classList.toggle('hidden');
+        }
+    }
+});
+
+loadTasks();


### PR DESCRIPTION
## Summary
- replace action buttons with icons and remove extra column
- move stats to a fixed bottom-left card and style tables as separate panels
- relocate new-task button to header for less clutter

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68c7f1723148832ba775c2b5f47f807a